### PR TITLE
Fix segfault issue with PGI compiler 

### DIFF
--- a/src/nrnoc/Makefile.am
+++ b/src/nrnoc/Makefile.am
@@ -216,7 +216,7 @@ if BUILD_MINGW
 else
 hocusr.h: $(nsrc)/nrnoc/neuron.h $(nsrc)/oc/mk_hocusr_h.py $(nsrc)/nrnoc/options.h
 	cat $(nsrc)/nrnoc/neuron.h > tmp.c
-	@CPP@ -I$(nsrc)/nrnoc -I$(nsrc)/oc tmp.c | sed '/^#/d' > neuron.tmp
+	@CPP@ -E -I$(nsrc)/nrnoc -I$(nsrc)/oc tmp.c | sed '/^#/d' > neuron.tmp
 	$(PYTHON_BLD) $(nsrc)/oc/mk_hocusr_h.py < neuron.tmp > temp2hoc
 	cat neuron.tmp temp2hoc |sed 's/"nrnhoc_topology"/"topology"/' > hocusr.h
 	rm -f temp1hoc temp2hoc neuron.tmp tmp.c

--- a/src/oc/mk_hocusr_h.py
+++ b/src/oc/mk_hocusr_h.py
@@ -55,7 +55,8 @@ static VoidFunc function[] = {
 ''')
 
 for i in voidfun:
-  print('"%s", %s,'%(i,i))
+  if i:
+    print('"%s", %s,'%(i,i))
 print('''0, 0
 };
 

--- a/src/oc/mk_hocusr_h.py
+++ b/src/oc/mk_hocusr_h.py
@@ -36,9 +36,7 @@ def process(type, names):
 
 
 # read preprocessor output file into buffer
-text = ''
-for line in sys.stdin:
-  text += line
+text = sys.stdin.read()
 
 # the PGI preprocessor output i.e. 'pgcc -Mcpp -E'
 # has multi-line comments (unless we specify -Mcpp=nocomment).

--- a/src/oc/mk_hocusr_h.py
+++ b/src/oc/mk_hocusr_h.py
@@ -1,5 +1,5 @@
 import sys
-
+import re
 
 voidfun = []
 intvar = [[],[]] #scalarint vectorint
@@ -20,6 +20,11 @@ def processvar(a, names):
       b.append(j.strip(']'))
     a[len(b)-1].append(b)
 
+def remove_multiline_comments(string):
+    # remove all occurance comments (/*COMMENT */) from string
+    string = re.sub(re.compile("/\*.*?\*/",re.DOTALL ) ,"" ,string)
+    return string
+
 types = {}
 types['void'] = (voidfun, processfun)
 types['int'] = (intvar, processvar)
@@ -29,7 +34,18 @@ types['double'] = (dblvar, processvar)
 def process(type, names):
   types[type][1](types[type][0], names)
 
+
+# read preprocessor output file into buffer
+text = ''
 for line in sys.stdin:
+  text += line
+
+# the PGI preprocessor output i.e. 'pgcc -Mcpp -E'
+# has multi-line comments (unless we specify -Mcpp=nocomment).
+# we need to remove these multi-line comments
+text = remove_multiline_comments(text)
+
+for line in text.splitlines():
   names = line.replace(',',' ').replace(';',' ').split()
   if len(names) > 2:
     process(names[1], names[2:])


### PR DESCRIPTION
PGI preprocessor output is written to tmp.i file
instead of stdout. Add -E flag to send output to
stdout. Update python script to handle extra multi-line
comments in preprocessor output from PGI compiler.