### PR TITLE
Use $(notdir $@) to avoid double concatenation of file path (with older make versions)

### DIFF
--- a/src/nrnoc/Makefile.am
+++ b/src/nrnoc/Makefile.am
@@ -119,8 +119,8 @@ $(MODFILES_C): $(NMODL)
 
 %.c: %.mod
 	(export MODLUNIT=$(top_srcdir)/share/lib/nrnunits.lib; $(NMODL) $<)
-	sed "s/_reg()/_reg_()/" $(srcdir)/$@ > $(srcdir)/$@.tmp
-	mv $(srcdir)/$@.tmp $(srcdir)/$@
+	sed "s/_reg()/_reg_()/" $(srcdir)/$(notdir $@) > $(srcdir)/$(notdir $@).tmp
+	mv $(srcdir)/$(notdir $@).tmp $(srcdir)/$(notdir $@)
 
 ## Force make to make hocusr.h even before it's done dependency scanning.
 hocusr.lo: hocusr.h


### PR DESCRIPTION
Current rule:

```
       sed "s/_reg()/_reg_()/" $(srcdir)/$@ > $(srcdir)/$@.tmp
       mv $(srcdir)/$@.tmp $(srcdir)/$@
```

With Make version (3.81), end-up with the path (see extra path appended after `../neuron/src/nrnoc`):

```
mv /gpfs/bbp.cscs.ch/project/proj16/kumbhar/sources/viz_ddt/sources/nrnmpi/../neuron/src/nrnoc//gpfs/bbp.cscs.ch/project/proj16/kumbhar/sources/viz_ddt/sources/nrnmpi/../neuron/src/nrnoc/hh.c.tmp /gpfs/bbp.cscs.ch/project/proj16/kumbhar/sources/viz_ddt/sources/nrnmpi/../neuron/src/nrnoc//gpfs/bbp.cscs.ch/project/proj16/kumbhar/sources/viz_ddt/sources/nrnmpi/../neuron/src/nrnoc/hh.c
mv: cannot stat `/gpfs/bbp.cscs.ch/project/proj
```

Built-in expansion functions `notdir ` for:

```
$(notdir names…)

Extracts all but the directory-part of each file name in names. If the file name contains no slash, it is left unchanged. Otherwise, everything through the last slash is removed from it.
```

Tested this on lugano viz cluster with `make v3.8`.