### PR TITLE
Fix for homebrew installed python3 on OS X  (fix #36)

### DIFF
--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -10,6 +10,12 @@ case "$TRAVIS_OS_NAME" in
         brew install flex bison modules
         brew install python3
 
+        # NOTE: brew installed python3 on OSX has known issue
+        # See https://stackoverflow.com/questions/24257803/
+        rm -f ~/.pydistutils.cfg
+        echo "[install]" > ~/.pydistutils.cfg
+        echo "prefix=" >> ~/.pydistutils.cfg
+
         case "$MPI_LIB_NAME" in
             mpich|mpich3)
                 brew install mpich

--- a/.travis/install_neuron.sh
+++ b/.travis/install_neuron.sh
@@ -6,7 +6,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
         packages=(
-                "neuron@develop +python +mpi -shared %gcc ^python@2.7"
+                "neuron@develop +python +mpi +shared %gcc ^python@2.7"
                 "neuron@develop +python +mpi -shared %gcc ^python@3"
                 "neuron@develop -python -mpi -shared %gcc"
                 "neuron@develop +python +mpi +shared %gcc"
@@ -15,7 +15,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         )
     else
         packages=(
-                "neuron@develop +python +mpi -shared %clang ^python@2.7"
+                "neuron@develop +python +mpi +shared %clang ^python@2.7"
                 "neuron@develop -python -mpi -shared %clang"
                 "neuron@develop +python +mpi +shared %clang ^python@3"
                 "neuron@develop +python +mpi +shared %gcc ^python@2.7"


### PR DESCRIPTION
Hi Michael,

As pointer out by @wvangeit, for brew installed pytho3 on OSX, we have to add entry in`~/.pydistutils.cfg`. Travis now builds NEURON with `+python +shared` as default setting and generates module with PYTHONPATH:

```
prepend-path	 PYTHONPATH /Users/travis/build/.../neuron-develop-3hzj/lib/python 
```