### PR TITLE
Minor changes for travis OS X build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   global:
     - SPACK_ROOT=$TRAVIS_BUILD_DIR/spack
     - PATH=$SPACK_ROOT/bin:$PATH
+    - ARCHFLAGS="-arch x86_64"
 
 #=============================================================================
 # Build matrix

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -7,6 +7,7 @@ MPI_LIB_NAME="$1"
 
 case "$TRAVIS_OS_NAME" in
     osx)
+        brew update > /dev/null
         brew install flex bison modules
         brew install python3
 

--- a/.travis/install_neuron.sh
+++ b/.travis/install_neuron.sh
@@ -29,13 +29,13 @@ else
         packages=(
                 "neuron@develop -python -mpi -shared %gcc"
                 "neuron@develop +python +mpi +shared %gcc ^python@2.7"
-                "neuron@develop +python +mpi +shared %gcc ^python@3"
+                "neuron@develop +python +mpi +shared %clang ^python@3"
                  )
     else
         packages=(
                 "neuron@develop -python -mpi -shared %clang"
                 "neuron@develop +python +mpi +shared %clang ^python@2.7"
-                "neuron@develop +python +mpi +shared %clang ^python@3"
+                "neuron@develop +python +mpi +shared %gcc ^python@3"
                  )
     fi
 
@@ -119,9 +119,9 @@ module avail
 
 # show generated module
 if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    name="neuron/develop-gcc-mpi-python3-shared"
+    name="neuron/develop-gcc-mpi-python2-shared"
 else
-    name="neuron/develop-clang-mpi-python3-shared"
+    name="neuron/develop-clang-mpi-python2-shared"
 fi
 
 

--- a/.travis/packages.osx.yaml
+++ b/.travis/packages.osx.yaml
@@ -47,9 +47,9 @@ packages:
     python:
         paths:
             python@2.7.12: /System/Library/Frameworks/Python.framework/Versions/2.7
-            python@3.6.2: /usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6
-        version: [2.7.12, 3.6.2]
+            python@3.6: /usr/local/opt/python3
         buildable: False
+        version: [2.7.12, 3.6]
     all:
         compiler: [clang, gcc@4.9]
         providers:


### PR DESCRIPTION
 - Update python version from 3.6.2 to 3.6.3
   Change python3 path to /usr/local/opt to avoid frequent updates
 - Fix for ruby 2.3 error on travis 
 - Set ARCHFLAGS for build with gcc on os x

@ Michael: I will suggest to wait until travis build finishes (once I create pull request)