### PR TITLE
Fix missing import leading to exception when subclassing NEURON classes

### DIFF
--- a/share/lib/python/neuron/hclass2.py
+++ b/share/lib/python/neuron/hclass2.py
@@ -6,6 +6,7 @@
 # ------------------------------------------------------------------------------
       
 from neuron import h, hoc
+import nrn
 
 class MetaHocObject(type):
   """Provides Exception for Inheritance of multiple HocObject"""

--- a/share/lib/python/neuron/hclass3.py
+++ b/share/lib/python/neuron/hclass3.py
@@ -6,6 +6,7 @@
 # ------------------------------------------------------------------------------
       
 from neuron import h, hoc
+import nrn
 
 class MetaHocObject(type):
   """Provides Exception for Inheritance of multiple HocObject"""


### PR DESCRIPTION
This fixes a crash for me that occurred in NEURON installed from rpm file or from sources.