### PR TITLE
Avoid writing negative gids to files.dat for coreneuron

### DIFF
--- a/src/nrniv/nrnbbcore_write.h
+++ b/src/nrniv/nrnbbcore_write.h
@@ -3,6 +3,9 @@
 
 #define DatumIndices nrncore_DatumIndices
 #define CellGroup nrncore_CellGroup
+
+#include <vector>
+
 struct Memb_list;
 
 // assume all Datum.pval point into this cell. In practice, this holds because
@@ -46,6 +49,12 @@ public:
   int ntype;
   DatumIndices* datumindices;
 };
+
+// returns start pointer of the container's data
+template <typename T>
+inline T* begin_ptr(std::vector<T>& v) {
+    return v.empty() ? NULL : &v[0];
+}
 
 #if defined(__cplusplus)
 extern "C" {


### PR DESCRIPTION
Hi Michael,

If we have less cells than total ranks, currently files.dat get generate with negative ids:

```
$ mpirun -n 8 nrniv -c nthread=1 ring.hoc -mpi
numprocs=8
NEURON -- VERSION 7.5 master (31c795d+) 2017-11-03
...
time	 cell
0.475	 0
13.45	 0
27.45	 0
41.4	 0
55.325	 0
69.25	 0
.....
51.85	 3
65.75	 3
79.675	 3
93.6	 3

 → cat files.dat
1.0
8
0
1
2
3
-1
-1
-1
-1
```
This commit filter those negative gids (non-existent datasets).

cc : @fouriaux