### PR TITLE
Update python paths in travis build configuration scripts

### DIFF
--- a/.travis/packages.linux.yaml
+++ b/.travis/packages.linux.yaml
@@ -47,9 +47,9 @@ packages:
         version: [5.4]
     python:
         paths:
-            python@2.7.13: /opt/python/2.7.13
-            python@3.5.3: /opt/python/3.5.3
-        version: [2.7.13, 3.5.3]
+            python@2.7: PYTHON_2_PATH
+            python@3.5: PYTHON_3_PATH
+        version: [2.7, 3.5]
         buildable: False
     all:
         compiler: [gcc, clang]

--- a/.travis/packages.osx.yaml
+++ b/.travis/packages.osx.yaml
@@ -46,10 +46,10 @@ packages:
         version: [5.7.2]
     python:
         paths:
-            python@2.7.12: /System/Library/Frameworks/Python.framework/Versions/2.7
-            python@3.6: /usr/local/opt/python3
+            python@2.7: PYTHON_2_PATH
+            python@3.6: PYTHON_3_PATH
         buildable: False
-        version: [2.7.12, 3.6]
+        version: [2.7, 3.6]
     all:
         compiler: [clang, gcc@4.9]
         providers:

--- a/.travis/setup_spack.sh
+++ b/.travis/setup_spack.sh
@@ -29,3 +29,18 @@ cp .travis/modules.yaml $HOME/.spack/
 
 # external packages are already installed on system, this install step just register them to spack
 spack install flex bison automake autoconf libtool pkg-config ncurses mpich openmpi python@3 python@2.7
+
+
+# find python2/3 to avoid hardcoded paths in packages.yaml
+PYTHON_2_PATH=`python -c "from distutils.sysconfig import get_config_var; print(get_config_var('prefix'))"`
+PYTHON_3_PATH=`python3 -c "from distutils.sysconfig import get_config_var; print(get_config_var('prefix'))"`
+
+
+# setup python path (gnu vs osx sed)
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    sed -i "s#PYTHON_2_PATH#$PYTHON_2_PATH#g" $HOME/.spack/packages.yaml
+    sed -i "s#PYTHON_3_PATH#$PYTHON_3_PATH#g" $HOME/.spack/packages.yaml
+else
+    sed -i '' "s#PYTHON_2_PATH#$PYTHON_2_PATH#g" $HOME/.spack/packages.yaml
+    sed -i '' "s#PYTHON_3_PATH#$PYTHON_3_PATH#g" $HOME/.spack/packages.yaml
+fi


### PR DESCRIPTION
- Python install prefix gets changed often with travis upgrade
- Instead of hardcoded path in `packages.yaml`, find python2/3 path using sysconfig and update build configuration files accordingly